### PR TITLE
Prevent illegal markup

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -186,6 +186,19 @@ var content = (function() {
       }
     },
 
+    getParentsAndSelf: function(node, tagName) {
+      var parents = [];
+      while (node) {
+        if (node.nodeType === nodeType.elementNode) {
+          if (!tagName || node.nodeName === tagName.toUpperCase()) {
+            parents.push(node);
+          }
+        }
+        node = node.parentNode;
+      }
+      return parents;
+    },
+
     /**
      * Get all tags that start or end inside the range
      */

--- a/src/selection.js
+++ b/src/selection.js
@@ -71,6 +71,16 @@ var Selection = (function() {
     },
 
     /**
+     * Check if a link can be added.
+     * If the editableHost or a parent is a link element linking
+     * should not be possible.
+     */
+    canLinkBeSet: function() {
+      var linkParents = content.getParentsAndSelf(this.host, 'a');
+      return linkParents.length ? false : true;
+    },
+
+    /**
      *
      * @method link
      */


### PR DESCRIPTION
- Editable should not set links if the host or a parent of the host is a link tag
- Consider adding general rules for allowed elements