### PR TITLE
Normalize newlines on paste

### DIFF
--- a/spec/clipboard.spec.js
+++ b/spec/clipboard.spec.js
@@ -73,6 +73,14 @@ describe('Clipboard', () => {
       checkWhitespace('a&nbsp;<span>b</span>', 'a b')
     })
 
+    it('collapses multiple whitespaces', () => {
+      checkWhitespace('A  B   C    D', 'A B C D')
+    })
+
+    it('removes newlines', () => {
+      checkWhitespace('A\nB \n C', 'A B C')
+    })
+
     // Remove Elements
     // ---------------
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -145,7 +145,10 @@ export function shouldKeepNode (nodeName, node) {
 }
 
 export function cleanWhitespace (str) {
-  return str.replace(/(.)\u00A0/g, (match, group) => group + (/[\u0020]/.test(group)
+  return str
+  .replace(/\n/g, ' ')
+  .replace(/ {2,}/g, ' ')
+  .replace(/(.)\u00A0/g, (match, group) => group + (/[\u0020]/.test(group)
     ? '\u00A0'
     : ' '
   ))


### PR DESCRIPTION
The browser represents newlines in HTML as spaces, and collapses multiples spaces.

This PR normalizes pasted content. The aim being for the HTML to be as close as possible to its representation in the browser.