### PR TITLE
Fix paste behaviour

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -5,7 +5,7 @@ import * as content from './content'
 import * as parser from './parser'
 import * as string from './util/string'
 import * as nodeType from './node-type'
-import * as error from './util/error'
+import error from './util/error'
 import * as rangeSaveRestore from './range-save-restore'
 
 /**

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -92,8 +92,21 @@ export default class Cursor {
     // Without setting focus() Firefox is not happy (seems setting a selection is not enough.
     // Probably because Firefox can handle multiple selections).
     if (this.win.document.activeElement !== this.host) {
+      const previousWindowTop = $(window).scrollTop()
+
       $(this.host).focus()
+
+      const hostBottom = $(this.host).position().top + $(this.host).outerHeight()
+      const windowHeight = $(window).height()
+      const isHostBottomVisible = hostBottom < previousWindowTop + windowHeight && hostBottom > previousWindowTop
+
+      if (isHostBottomVisible) {
+        $(window).scrollTop(previousWindowTop)
+      } else {
+        $(window).scrollTop(parseInt(hostBottom - windowHeight / 2, 10))
+      }
     }
+
     rangy.getSelection(this.win).setSingleRange(this.range)
   }
 

--- a/src/range-save-restore.js
+++ b/src/range-save-restore.js
@@ -1,5 +1,5 @@
 import rangy from 'rangy'
-import * as error from './util/error'
+import error from './util/error'
 import * as nodeType from './node-type'
 
 /**

--- a/src/util/error.js
+++ b/src/util/error.js
@@ -1,4 +1,4 @@
-import config from '../config'
+import * as config from '../config'
 
 // Allows for safe error logging
 // Falls back to console.log if console.error is not available


### PR DESCRIPTION
# Planning
https://github.com/upfrontIO/livingdocs-planning/issues/1576

## To reproduce

1. Make a very long paragraph that is longer than one viewport height (should have a scrollbar)
2. Move to the end of that paragraph and copy some content to the end

## Observed Behavior

The scroll position scrolls to the top of the paragraph and the place where the content was pasted is not visible anymore.

## Expected Behavior

The scroll position should not change.

## Video

https://drive.google.com/open?id=0Bya_F0ISZ6F8OUV4TTUwMmxNTU0

# Description
- The first commit fixes some import issues.
- The second commit tackles the main issue from the planning. We now disable the focus if we paste only one paragraph.

@peyerluk it looked to me as the simplest fix for the issue at hand. Can you assess its relevance? I'll look if it needs testing afterward.